### PR TITLE
start pulseaudio when user logs in and add pavucontrol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
 	firefox \
+	pavucontrol \
 	terminator \
 	xfce4 \
 	xfce4-goodies \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -12,6 +12,7 @@ RUN \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
 	firefox \
+	pavucontrol \
 	terminator \
 	xfce4 \
 	xfce4-goodies \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -12,6 +12,7 @@ RUN \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
 	firefox \
+	pavucontrol \
 	terminator \
 	xfce4 \
 	xfce4-goodies \

--- a/README.md
+++ b/README.md
@@ -245,4 +245,5 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **06.04.20:** - Start PulseAudio in images to support audio
 * **28.02.20:** - Initial Releases

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -68,4 +68,5 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "06.04.20:", desc: "Start PulseAudio in images to support audio" }
   - { date: "28.02.20:", desc: "Initial Releases" }

--- a/root/defaults/startwm.sh
+++ b/root/defaults/startwm.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+/usr/bin/pulseaudio --start
 /usr/bin/startxfce4 > /dev/null 2>&1


### PR DESCRIPTION
I am opening a PR for the master fix, but will handle all the other branches with direct commit/testing due to the amount of branches and babysitting involved with the builds. 

I added all the pulseaudio build crap to the baseimage and finally got around to loop testing audio support with different rdesktop clients. The user's session needs to start pulseaudio and for volume control need pavucontrol. 