### PR TITLE
modify the base packages to line up with flavor defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,9 @@ RUN \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
 	firefox \
-	pavucontrol \
-	terminator \
+	mousepad \
+	xfce4-terminal \
 	xfce4 \
-	xfce4-goodies \
 	xubuntu-default-settings \
 	xubuntu-icon-theme && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -12,10 +12,9 @@ RUN \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
 	firefox \
-	pavucontrol \
-	terminator \
+	mousepad \
+	xfce4-terminal \
 	xfce4 \
-	xfce4-goodies \
 	xubuntu-default-settings \
 	xubuntu-icon-theme && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -12,10 +12,9 @@ RUN \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
 	firefox \
-	pavucontrol \
-	terminator \
+	mousepad \
+	xfce4-terminal \
 	xfce4 \
-	xfce4-goodies \
 	xubuntu-default-settings \
 	xubuntu-icon-theme && \
  echo "**** cleanup ****" && \

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **05.05.21:** - Reduce default packages to their flavor specific basics.
 * **05.04.21:** - Add Alpine flavor.
 * **06.04.20:** - Start PulseAudio in images to support audio
 * **28.02.20:** - Initial Releases

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -69,6 +69,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "05.05.21:", desc: "Reduce default packages to their flavor specific basics." }
   - { date: "05.04.21:", desc: "Add Alpine flavor." }
   - { date: "06.04.20:", desc: "Start PulseAudio in images to support audio" }
   - { date: "28.02.20:", desc: "Initial Releases" }


### PR DESCRIPTION
This spans all the branches to sync up the default packages with webtop. Stop using terminator and use default flavor specific terminals and text editors.