### PR TITLE
modify the base packages to line up with flavor defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,10 @@ RUN \
 	faenza-icon-theme \
 	faenza-icon-theme-xfce4-appfinder \
 	faenza-icon-theme-xfce4-panel \
-	firefox \
+	firefox-esr \
 	font-noto \
 	mousepad \
-	setxkbmap \
-	thunar-volman \
+	thunar \
 	xfce4 \
 	xfce4-terminal && \
  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -12,11 +12,10 @@ RUN \
 	faenza-icon-theme \
 	faenza-icon-theme-xfce4-appfinder \
 	faenza-icon-theme-xfce4-panel \
-	firefox \
+	firefox-esr \
 	font-noto \
 	mousepad \
-	setxkbmap \
-	thunar-volman \
+	thunar \
 	xfce4 \
 	xfce4-terminal && \
  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -12,11 +12,10 @@ RUN \
 	faenza-icon-theme \
 	faenza-icon-theme-xfce4-appfinder \
 	faenza-icon-theme-xfce4-panel \
+	firefox-esr \
 	font-noto \
-	midori \
 	mousepad \
-	setxkbmap \
-	thunar-volman \
+	thunar \
 	xfce4 \
 	xfce4-terminal && \
  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \


### PR DESCRIPTION
This spans all the branches to sync up the default packages with webtop. Stop using terminator and use default flavor specific terminals and text editors.