### PR TITLE
modify the base packages to line up with flavor defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
 	firefox \
 	i3 \
 	i3status \
-	terminator && \
+	xterm && \
  echo "**** cleanup ****" && \
  apt-get autoclean && \
  rm -rf \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,7 +14,7 @@ RUN \
 	firefox \
 	i3 \
 	i3status \
-	terminator && \
+	xterm && \
  echo "**** cleanup ****" && \
  apt-get autoclean && \
  rm -rf \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,7 +14,7 @@ RUN \
 	firefox \
 	i3 \
 	i3status \
-	terminator && \
+	xterm && \
  echo "**** cleanup ****" && \
  apt-get autoclean && \
  rm -rf \


### PR DESCRIPTION
This spans all the branches to sync up the default packages with webtop. Stop using terminator and use default flavor specific terminals and text editors.