### PR TITLE
modify the base packages to line up with flavor defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN \
  apt-get update && \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
+	featherpad \
 	firefox \
 	obconf \
 	openbox \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -11,6 +11,7 @@ RUN \
  apt-get update && \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
+	featherpad \
 	firefox \
 	obconf \
 	openbox \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -11,6 +11,7 @@ RUN \
  apt-get update && \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
+	featherpad \
 	firefox \
 	obconf \
 	openbox \

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openbox_menu xmlns="http://openbox.org/3.4/menu">
+<menu id="root-menu" label="MENU">
+<item label="xterm" icon="/usr/share/icons/hicolor/48x48/apps/xterm-color.png"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
+<item label="Featherpad" icon="/usr/share/icons/hicolor/scalable/apps/featherpad.svg"><action name="Execute"><command>/usr/bin/featherpad</command></action></item>
+<item label="Firefox" icon="/usr/share/icons/hicolor/48x48/apps/firefox.png"><action name="Execute"><command>/usr/bin/firefox</command></action></item>
+<item label="OBConf" icon="/usr/share/pixmaps/obconf.png"><action name="Execute"><command>/usr/bin/obconf</command></action></item>
+<item label="Reload OB"><action name="Reconfigure"/></item>
+</menu>
+</openbox_menu>

--- a/root/etc/cont-init.d/56-openboxcopy
+++ b/root/etc/cont-init.d/56-openboxcopy
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv bash
+
+# default file copies first run
+[[ ! -f /config/.config/openbox/menu.xml ]] && \
+    mkdir -p /config/.config/openbox && \
+    cp /defaults/menu.xml /config/.config/openbox/menu.xml && \
+    chown -R abc:abc /config/.config


### PR DESCRIPTION
This spans all the branches to sync up the default packages with webtop. Stop using terminator and use default flavor specific terminals and text editors.