### PR TITLE
modify the base packages to line up with flavor defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,9 @@ RUN \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
 	firefox \
-	pavucontrol \
-	terminator \
+	mousepad \
+	xfce4-terminal \
 	xfce4 \
-	xfce4-goodies \
 	xubuntu-default-settings \
 	xubuntu-icon-theme && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -12,10 +12,9 @@ RUN \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
 	firefox \
-	pavucontrol \
-	terminator \
+	mousepad \
+	xfce4-terminal \
 	xfce4 \
-	xfce4-goodies \
 	xubuntu-default-settings \
 	xubuntu-icon-theme && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -12,10 +12,9 @@ RUN \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
 	firefox \
-	pavucontrol \
-	terminator \
+	mousepad \
+	xfce4-terminal \
 	xfce4 \
-	xfce4-goodies \
 	xubuntu-default-settings \
 	xubuntu-icon-theme && \
  echo "**** cleanup ****" && \


### PR DESCRIPTION
This spans all the branches to sync up the default packages with webtop. Stop using terminator and use default flavor specific terminals and text editors.