### PR TITLE
modify the base packages to line up with flavor defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ RUN \
  apt-get update && \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
+	dolphin \
 	firefox \
+	kate \
 	kmix \
-	kubuntu-desktop \
-	terminator && \
+	konsole \
+	kubuntu-desktop && \
  echo "**** cleanup ****" && \
  apt-get autoclean && \
  rm -rf \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -11,10 +11,12 @@ RUN \
  apt-get update && \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
+	dolphin \
 	firefox \
+	kate \
 	kmix \
-	kubuntu-desktop \
-	terminator && \
+	konsole \
+	kubuntu-desktop && \
  echo "**** cleanup ****" && \
  apt-get autoclean && \
  rm -rf \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -11,10 +11,12 @@ RUN \
  apt-get update && \
  DEBIAN_FRONTEND=noninteractive \
  apt-get install --no-install-recommends -y \
+	dolphin \
 	firefox \
+	kate \
 	kmix \
-	kubuntu-desktop \
-	terminator&& \
+	konsole \
+	kubuntu-desktop && \
  echo "**** cleanup ****" && \
  apt-get autoclean && \
  rm -rf \


### PR DESCRIPTION
This spans all the branches to sync up the default packages with webtop. Stop using terminator and use default flavor specific terminals and text editors.