### PR TITLE
modify the base packages to line up with flavor defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN \
 	firefox \
 	mate-applets \
 	mate-applet-brisk-menu \
-	pavucontrol \
-	terminator \
+	mate-terminal \
+	pluma \
 	ubuntu-mate-artwork \
 	ubuntu-mate-default-settings \
 	ubuntu-mate-desktop \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -14,8 +14,8 @@ RUN \
 	firefox \
 	mate-applets \
 	mate-applet-brisk-menu \
-	pavucontrol \
-	terminator \
+	mate-terminal \
+	pluma \
 	ubuntu-mate-artwork \
 	ubuntu-mate-default-settings \
 	ubuntu-mate-desktop \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,8 +14,8 @@ RUN \
 	firefox \
 	mate-applets \
 	mate-applet-brisk-menu \
-	pavucontrol \
-	terminator \
+	mate-terminal \
+	pluma \
 	ubuntu-mate-artwork \
 	ubuntu-mate-default-settings \
 	ubuntu-mate-desktop \


### PR DESCRIPTION
This spans all the branches to sync up the default packages with webtop. Stop using terminator and use default flavor specific terminals and text editors.